### PR TITLE
removed two unneeded clears

### DIFF
--- a/main.s
+++ b/main.s
@@ -16,8 +16,6 @@ init:
     ; can't depend on the bios to clear regs
     xor ax, ax
     xor bx, bx
-    xor cx, cx
-    xor dx, dx
     xor si, si
     xor di, di
 


### PR DESCRIPTION
the mov further down sets the registers just fine, verified on hardware